### PR TITLE
Adding batching for association access

### DIFF
--- a/lib/graphql/activerecord.rb
+++ b/lib/graphql/activerecord.rb
@@ -7,7 +7,7 @@ require 'graphql/models/active_record_extension'
 
 # Helpers
 require 'graphql/models/definer'
-require 'graphql/models/load_request'
+require 'graphql/models/association_load_request'
 require 'graphql/models/loader'
 
 # Order matters...

--- a/lib/graphql/activerecord.rb
+++ b/lib/graphql/activerecord.rb
@@ -7,6 +7,8 @@ require 'graphql/models/active_record_extension'
 
 # Helpers
 require 'graphql/models/definer'
+require 'graphql/models/load_request'
+require 'graphql/models/loader'
 
 # Order matters...
 require 'graphql/models/identification'

--- a/lib/graphql/models/definition_helpers.rb
+++ b/lib/graphql/models/definition_helpers.rb
@@ -5,6 +5,19 @@ module GraphQL
         GraphQL::DefinitionHelpers::TypeDefiner.instance
       end
 
+      # Returns a promise that will eventually resolve to the model that is at the end of the path
+      def self.load_and_traverse(current_model, path, context)
+        return Promise.resolve(current_model) if path.length == 0
+
+        request = AssociationLoadRequest.new(current_model, path[0], context)
+        Loader.for(request.target_class).load(request).then do |next_model|
+          next nil unless next_model
+          next next_model if path.length == 1
+
+          DefinitionHelpers.load_and_traverse(next_model, path[1..-1], context)
+        end
+      end
+
       def self.traverse_path(base_model, path, context)
         model = base_model
         path.each do |segment|
@@ -32,11 +45,11 @@ module GraphQL
 
         definer.noauth_field camel_name, attr_type.graph_type_proc do
           resolve -> (base_model, args, context) do
-            model = DefinitionHelpers.traverse_path(base_model, path, context)
-            return nil unless model
-            return nil unless context.can?(:read, model)
-
-            return attr_type.resolve(model, field_name)
+            DefinitionHelpers.load_and_traverse(base_model, path, context).then do |model|
+              next nil unless model
+              next nil unless context.can?(:read, model)
+              next attr_type.resolve(model, field_name)
+            end
           end
         end
       end

--- a/lib/graphql/models/definition_helpers/associations.rb
+++ b/lib/graphql/models/definition_helpers/associations.rb
@@ -31,7 +31,7 @@ module GraphQL
         valid_types = detect_inclusion_values(model_type, reflection.foreign_type)
 
         if valid_types.blank?
-          fail ArgumentError.new("Cannot include polymorphic #{reflection.name} association on model #{model_type.name}, because it does not define an inclusion validator on #{refleciton.foreign_type}")
+          fail ArgumentError.new("Cannot include polymorphic #{reflection.name} association on model #{model_type.name}, because it does not define an inclusion validator on #{reflection.foreign_type}")
         end
 
         return ->() do

--- a/lib/graphql/models/load_request.rb
+++ b/lib/graphql/models/load_request.rb
@@ -1,0 +1,104 @@
+module GraphQL
+  module Models
+    class AssociationLoadRequest
+      attr_reader :base_model, :association, :context
+
+      def initialize(base_model, association_name, context)
+        @base_model = base_model
+        @association = base_model.association(association_name)
+      end
+
+      def reflection
+        association.reflection
+      end
+
+      def model_cache
+        return nil unless context
+        context.model_cache[target_class] ||= {}
+      end
+
+      def target_class
+        case when reflection.polymorphic?
+          base_model.send(reflection.foreign_type).constantize
+        else
+          reflection.klass
+        end
+      end
+
+      def eager_fulfill
+        return unless context
+
+        yield association.target and return if association.loaded?
+
+        if reflection.macro == :belongs_to
+          id = base_model.send(reflection.foreign_key)
+
+          yield nil and return if id.nil?
+          yield model_cache[id] and return if model_cache.include?(id)
+
+        elsif reflection.macro == :has_one
+
+          model = model_cache.values.detect do |m|
+            m.send(reflection.foreign_key) == base_model.id && (!reflection.options.include?[:as] || m.send(reflection.foreign_type) == base_model.class.name)
+          end
+
+          yield model and return unless model.nil?
+        end
+      end
+
+      def in_clause_type
+        case reflection.macro
+        when :belongs_to
+          :id
+        else
+          :query
+        end
+      end
+
+      # The resulting query will be something like "where id in (...)". This method needs to return the contents
+      # of that 'in' clause.
+      def in_clause
+        case reflection.macro
+        when :belongs_to
+          base_model.send(reflection.foreign_key)
+        else
+          condition = { reflection.foreign_key => base_model.id }
+
+          if reflection.options.include?(:as)
+            condition[reflection.foreign_type] = base_model.class.name
+          end
+
+          target_class.where(condition).select(:id).to_sql
+        end
+      end
+
+      # If the value should be an array, make sure it's an array. If it should be a single value, make sure it's single.
+      # Passed in result could be a single model or an array of models.
+      def ensure_cardinality(result)
+        case reflection.macro
+        when :has_many
+          Array.wrap(result)
+        else
+          result.is_a?(Array) ? result[0] : result
+        end
+      end
+
+      # When the request is fulfilled, this method is called so that it can do whatever caching, etc. is needed
+      def fulfilled(result)
+        association.loaded!
+
+        if reflection.macro == :has_many
+          association.target.concat(result)
+          result.each do |m|
+            association.set_inverse_instance(m)
+            model_cache[m.id] = m if model_cache
+          end
+        else
+          association.target = result
+          association.set_inverse_instance(result)
+          model_cache[result.id] = result if model_cache
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/models/loader.rb
+++ b/lib/graphql/models/loader.rb
@@ -1,0 +1,68 @@
+module GraphQL
+  module Models
+    class Loader < GraphQL::Batch::Loader
+      attr_reader :model_class
+
+      def initialize(model_class)
+        @model_class = model_class
+      end
+
+      def perform(load_requests)
+        # Each load request should return a SQL query that returns a list of ID's for the models
+        # that the request is asking to have loaded.
+
+        # If the request can be eager fulfilled, exclude it from the result
+        load_requests.each do |request|
+          request.eager_fulfill { |result| fulfill_request(request, model) }
+        end
+
+        load_requests = load_requests.reject { |r| fulfilled?(r) }
+        return if load_requests.empty?
+
+        grouped = load_requests.group_by(&:in_clause_type)
+
+        id_requests = grouped[:id] || []
+        query_requests = grouped[:query] || []
+
+        queries = query_requests.map { |r| model_class.where("#{model_class.table_name}.id in (#{r.in_clause})").select(:id).to_sql }
+
+        # We want to build a query that will return all of the models that match any of the queries,
+        # and we want the server to also tell us which ones matched that particular query
+        extra_columns = query_requests.each_with_index.map do |request, index|
+          "CASE WHEN #{model_class.table_name}.id IN (#{request.in_clause}) THEN true ELSE false END AS load_req_#{index}"
+        end
+
+        conditions = []
+        if id_requests.any?
+          first = id_requests[0].in_clause
+          id_values = id_requests.map { |r| ActiveRecord::Base.sanitize(r.in_clause) }.join(', ')
+          conditions.push("#{model_class.table_name}.id in (#{id_values})")
+        end
+
+        if queries.any?
+          union = queries.join(' UNION ')
+          conditions.push("#{model_class.table_name}.id in (#{union})")
+        end
+
+        result = @model_class.where(conditions.join(" OR ")).select(["#{model_class.table_name}.*", *extra_columns].join(', '))
+
+        id_requests.each do |req|
+          model = result.detect { |m| m.id == req.in_clause }
+          fulfill_request(req, model)
+        end
+
+        query_requests.each_with_index do |req, idx|
+          loaded_column = "load_req_#{idx}"
+          models = result.select { |m| m[loaded_column] }
+          fulfill_request(req, models)
+        end
+      end
+
+      def fulfill_request(request, result)
+        result = request.ensure_cardinality(result)
+        request.fulfilled(result)
+        fulfill(request, result)
+      end
+    end
+  end
+end

--- a/lib/graphql/models/monkey_patches/graphql_query_context.rb
+++ b/lib/graphql/models/monkey_patches/graphql_query_context.rb
@@ -11,4 +11,8 @@ class GraphQL::Query::Context
     return true unless ability
     ability.can?(action, subject, *extra_args)
   end
+
+  def model_cache
+    @model_cache ||= {}
+  end
 end


### PR DESCRIPTION
* Improves the batching support for GraphQL queries

#### Before
When you defined a `proxy_to`, `has_one`, or `has_many_array`, this gem would build a path that described how to get from the starting model (eg, `Employee`) to the end model (eg, `[:person, :address]`).

It would then use a loop to successively load each model by accessing the association property (eg, `employee.send(:person)`).

This relied on the `golidloader` gem, which is smart enough to know that if I have a collection of employees, and I access the `person` on the first one, it should actually load the `person` for _all_ of them.

The limitation is that `goldiloader` starts getting tripped up if you are accessing values more than one level deep (eg, `employee.manager.person`), or if you've customized the association (eg, `.includes`, `.limit`, etc).

#### After
Associations that are _not_ connections (ie, `proxy_to`, `has_one`, `has_many_array`) are now loaded using `graphql-batch`'s promise system.

When accessing a field that uses one of these values, the field will actually return a _promise_ that will eventually resolve to the value that you need. The `graphql-batch` gem knows how to batch together queries that are trying to access the same type of model.

Also, it's smarter about how it handles models once they're loaded:
* If it retrieved the model from the database previously, it caches it for the same GraphQL query and will use it later if it's requested again. (For example, Employee -> Manager if the manager was already loaded)
* When it loads the models, it makes sure to update the associations, so that active record knows that the model has been loaded