### PR TITLE
Connection batching

### DIFF
--- a/lib/graphql/activerecord.rb
+++ b/lib/graphql/activerecord.rb
@@ -3,6 +3,7 @@ require 'graphql'
 require 'graphql/models/monkey_patches/base_type'
 require 'graphql/models/monkey_patches/graphql_relay_global_node_identification'
 require 'graphql/models/monkey_patches/graphql_query_context'
+require 'graphql/models/monkey_patches/graphql_relay_connection_field'
 require 'graphql/models/active_record_extension'
 
 # Helpers
@@ -11,6 +12,8 @@ require 'graphql/models/association_load_request'
 require 'graphql/models/loader'
 
 # Order matters...
+require 'graphql/models/promise_relation_connection'
+require 'graphql/models/relation_load_request'
 require 'graphql/models/identification'
 require 'graphql/models/identification/attribute_type_definition'
 require 'graphql/models/identification/attribute_types'

--- a/lib/graphql/models/association_load_request.rb
+++ b/lib/graphql/models/association_load_request.rb
@@ -13,51 +13,32 @@ module GraphQL
       # Public members that all load requests should implement
       ####################################################################
 
-      def eager_fulfill
-        return unless context
-
-        yield association.target and return if association.loaded?
-
-        if reflection.macro == :belongs_to
-          id = base_model.send(reflection.foreign_key)
-
-          yield nil and return if id.nil?
-          yield model_cache[id] and return if model_cache.include?(id)
-
-        elsif reflection.macro == :has_one
-
-          model = model_cache.values.detect do |m|
-            m.send(reflection.foreign_key) == base_model.id && (!reflection.options.include?[:as] || m.send(reflection.type) == base_model.class.name)
-          end
-
-          yield model and return unless model.nil?
-        end
-      end
-
-
-      def in_clause_type
+      def load_type
         case reflection.macro
         when :belongs_to
           :id
         else
-          :query
+          :relation
         end
       end
 
       # The resulting query will be something like "where id in (...)". This method needs to return the contents
       # of that 'in' clause.
-      def in_clause
+      def load_target
         case reflection.macro
         when :belongs_to
           base_model.send(reflection.foreign_key)
+        when :has_many
+          base_model.send(association.reflection.name)
         else
+          # has_one, need to construct our own relation, because accessing the relation will load the model
           condition = { reflection.foreign_key => base_model.id }
 
           if reflection.options.include?(:as)
             condition[reflection.type] = base_model.class.name
           end
 
-          target_class.where(condition).select(:id).to_sql
+          target_class.where(condition)
         end
       end
 
@@ -80,15 +61,12 @@ module GraphQL
           association.target.concat(result)
           result.each do |m|
             association.set_inverse_instance(m)
-            model_cache[m.id] = m if model_cache
           end
         else
           association.target = result
           association.set_inverse_instance(result)
-          model_cache[result.id] = result if model_cache
         end
       end
-
 
       #################################################################
       # Public members specific to an association load request
@@ -106,11 +84,6 @@ module GraphQL
 
       def reflection
         association.reflection
-      end
-
-      def model_cache
-        return nil unless context
-        context.model_cache[target_class] ||= {}
       end
 
     end

--- a/lib/graphql/models/association_load_request.rb
+++ b/lib/graphql/models/association_load_request.rb
@@ -21,9 +21,7 @@ module GraphQL
           :relation
         end
       end
-
-      # The resulting query will be something like "where id in (...)". This method needs to return the contents
-      # of that 'in' clause.
+      
       def load_target
         case reflection.macro
         when :belongs_to

--- a/lib/graphql/models/definition_helpers.rb
+++ b/lib/graphql/models/definition_helpers.rb
@@ -7,25 +7,71 @@ module GraphQL
 
       # Returns a promise that will eventually resolve to the model that is at the end of the path
       def self.load_and_traverse(current_model, path, context)
+        cache_model(context, current_model)
         return Promise.resolve(current_model) if path.length == 0
 
         association = current_model.association(path[0])
 
-        # If the model is already loaded, we can return it immediately
-        # Else if we know that the associated model is nil, we can return nil immediately
-        if association.loaded?
+        if association.loaded? || attempt_cache_load(current_model, association, context)
+          cache_model(context, association.target)
           return Promise.resolve(association.target)
-        elsif association.reflection.macro == :belongs_to && current_model.send(association.reflection.foreign_key).nil?
-          return Promise.resolve(nil)
         end
 
         request = AssociationLoadRequest.new(current_model, path[0], context)
         Loader.for(request.target_class).load(request).then do |next_model|
           next nil unless next_model
-          next next_model if path.length == 1
 
-          DefinitionHelpers.load_and_traverse(next_model, path[1..-1], context)
+          if path.length == 1
+            cache_model(context, next_model)
+            next next_model
+          else
+            DefinitionHelpers.load_and_traverse(next_model, path[1..-1], context)
+          end
         end
+      end
+
+      # Attempts to retrieve the model from the query's cache. If it's found, the association is marked as
+      # loaded and the model is added. This only works for belongs_to and has_one associations.
+      def self.attempt_cache_load(model, association, context)
+        return false unless context
+
+        reflection = association.reflection
+        return false unless [:has_one, :belongs_to].include?(reflection.macro)
+
+        if reflection.macro == :belongs_to
+          target_id = model.send(reflection.foreign_key)
+
+          # If there isn't an associated model, mark the association loaded and return
+          mark_association_loaded(association, nil) and return true if target_id.nil?
+
+          # If the associated model isn't cached, return false
+          target = context.cached_models.detect { |m| m.is_a?(association.klass) && m.id == target_id }
+          return false unless target
+
+          # Found it!
+          mark_association_loaded(association, target)
+          return true
+        else
+          target = context.cached_models.detect do |m|
+            m.is_a?(association.klass) && m.send(reflection.foreign_key) == model.id && (!reflection.options.include?[:as] || m.send(reflection.type) == model.class.name)
+          end
+
+          return false unless target
+
+          mark_association_loaded(association, target)
+          return true
+        end
+      end
+
+      def self.cache_model(context, model)
+        return unless context
+        context.cached_models.merge(Array.wrap(model))
+      end
+
+      def self.mark_association_loaded(association, target)
+        association.loaded!
+        association.target = target
+        association.set_inverse_instance(target) unless target.nil?
       end
 
       def self.traverse_path(base_model, path, context)

--- a/lib/graphql/models/monkey_patches/graphql_query_context.rb
+++ b/lib/graphql/models/monkey_patches/graphql_query_context.rb
@@ -12,7 +12,7 @@ class GraphQL::Query::Context
     ability.can?(action, subject, *extra_args)
   end
 
-  def model_cache
-    @model_cache ||= {}
+  def cached_models
+    @cached_models ||= Set.new
   end
 end

--- a/lib/graphql/models/monkey_patches/graphql_relay_connection_field.rb
+++ b/lib/graphql/models/monkey_patches/graphql_relay_connection_field.rb
@@ -1,0 +1,22 @@
+# This is only a temporary monkey patch...
+class GraphQL::Relay::ConnectionField
+  class << self
+    def get_connection_resolve(field_name, underlying_resolve, max_page_size: nil)
+      -> (obj, args, ctx) {
+         items = underlying_resolve.call(obj, args, ctx)
+
+         # In the original version of this method, the following line was:
+         # if items == GraphQL::Query::DEFAULT_RESOLVE
+         # The problme is that if items.is_a?(ActiveRecord::Relation), this uses the relation's equality checker,
+         # and that equality check will load the relation.
+
+         if GraphQL::Query::DEFAULT_RESOLVE == items
+           items = obj.public_send(field_name)
+         end
+
+         connection_class = GraphQL::Relay::BaseConnection.connection_for_items(items)
+         connection_class.new(items, args, max_page_size: max_page_size)
+       }
+    end
+  end
+end

--- a/lib/graphql/models/promise_relation_connection.rb
+++ b/lib/graphql/models/promise_relation_connection.rb
@@ -1,0 +1,22 @@
+module GraphQL
+  module Models
+    class PromiseRelationConnection < GraphQL::Relay::RelationConnection
+      def edges
+        # Can't do any optimization if the request is asking for the last X items, since there's
+        # no easy way to turn it into a generalized query.
+        return super if last
+
+        relation = sliced_nodes
+        limit = [first, last, max_page_size].compact.min
+        relation = relation.limit(limit) if first
+        request = RelationLoadRequest.new(relation)
+
+        Loader.for(request.target_class).load(request).then do |models|
+          models.map { |m| GraphQL::Relay::Edge.new(m, self) }
+        end
+      end
+    end
+
+    GraphQL::Relay::BaseConnection.register_connection_implementation(ActiveRecord::Relation, PromiseRelationConnection)
+  end
+end

--- a/lib/graphql/models/relation_load_request.rb
+++ b/lib/graphql/models/relation_load_request.rb
@@ -1,0 +1,42 @@
+module GraphQL
+  module Models
+    class RelationLoadRequest
+      attr_reader :relation
+
+      def initialize(relation)
+        @relation = relation
+      end
+
+      ####################################################################
+      # Public members that all load requests should implement
+      ####################################################################
+
+      def load_type
+        :relation
+      end
+
+      def load_target
+        relation
+      end
+
+      # If the value should be an array, make sure it's an array. If it should be a single value, make sure it's single.
+      # Passed in result could be a single model or an array of models.
+      def ensure_cardinality(result)
+        Array.wrap(result)
+      end
+
+      # When the request is fulfilled, this method is called so that it can do whatever caching, etc. is needed
+      def fulfilled(result)
+      end
+
+      #################################################################
+      # Public members specific to a relation load request
+      #################################################################
+
+      def target_class
+        relation.klass
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
* Makes it possible to using batching for connections, or more complicated associations
* Preserves ordering on the results of batched queries
* Moves caching out of the batching layer
