### PR TITLE
Preparing for graphql 0.12

### DIFF
--- a/graphql-activerecord.gemspec
+++ b/graphql-activerecord.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*", "MIT_LICENSE", "readme.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_runtime_dependency "graphql", "~> 0.10"
-  s.add_runtime_dependency "graphql-relay", "~> 0.7"
+  s.add_runtime_dependency "graphql", "~> 0.11.0"
+  s.add_runtime_dependency "graphql-relay", "~> 0.7.0"
 end

--- a/lib/graphql/activerecord.rb
+++ b/lib/graphql/activerecord.rb
@@ -26,3 +26,23 @@ require 'graphql/models/definition_helpers/associations'
 require 'graphql/models/definition_helpers/attributes'
 require 'graphql/models/model_type_config'
 require 'graphql/models/model_type'
+
+module GraphQL
+  module Models
+    # Returns a promise that will traverse the associations and resolve to the model at the end of the path.
+    # You can use this to access associated models inside custom field resolvers, without losing optimization
+    # benefits.
+    def self.load_association(starting_model, path, context)
+      GraphQL::Models::DefinitionHelpers.load_and_traverse(starting_model, path, context)
+    end
+
+    def self.field_info(model_type, field_name)
+      field_name = field_name.to_s
+
+      meta = model_type.instance_variable_get(:@_graphql_field_metadata)
+      return nil unless meta
+
+      meta[field_name]
+    end
+  end
+end

--- a/lib/graphql/models/model_type_config.rb
+++ b/lib/graphql/models/model_type_config.rb
@@ -9,14 +9,15 @@ module GraphQL
       end
 
       def standard_fields
-        noauth_field :id, field: GraphQL::Relay::GlobalIdField.new(name)
+        field :id, field: GraphQL::Relay::GlobalIdField.new(name)
+
         interfaces [NodeIdentification.interface]
 
-        noauth_field :rid, !types.String do
+        field :rid, !types.String do
           resolve proc { |model| model.id }
         end
 
-        noauth_field :rtype, !types.String do
+        field :rtype, !types.String do
           resolve proc { |model| model.class.name }
         end
 
@@ -30,20 +31,6 @@ module GraphQL
         end
 
         @interfaces
-      end
-
-      alias_method :noauth_field, :field
-
-      def field(*outer_args)
-        field = super
-
-        resolver = field.resolve_proc
-        field.resolve = -> (model, args, context) do
-          return nil unless context.can?(:read, model)
-          resolver.call(model, args, context)
-        end
-
-        field
       end
 
       def proxy_to(association, &block)

--- a/lib/graphql/models/monkey_patches/graphql_query_context.rb
+++ b/lib/graphql/models/monkey_patches/graphql_query_context.rb
@@ -1,17 +1,4 @@
 class GraphQL::Query::Context
-  def include?(item)
-    !!(@values && @values.include?(item))
-  end
-
-  def ability
-    @values[:ability] if include?(:ability)
-  end
-
-  def can?(action, subject, *extra_args)
-    return true unless ability
-    ability.can?(action, subject, *extra_args)
-  end
-
   def cached_models
     @cached_models ||= Set.new
   end

--- a/lib/graphql/models/version.rb
+++ b/lib/graphql/models/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Models
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
This PR moves most of the security checks out of this gem (should use middleware instead).

Also, it starts to expose public utility methods:
#### `GraphQL::Models.load_association`
Exposes the optimized code for loading associated models. Can be used in custom field resolver methods to get the benefits of query batching.

#### `GraphQL::Models.field_info`: 
Given a model class (ie, inheriting from `ActiveRecord::Base`) and the name of a GraphQL field (on its corresponding GraphQL type), returns information describing how that field maps to an attribute or association on the model.