### PR TITLE
Benefitsql

### DIFF
--- a/lib/graphql/activerecord.rb
+++ b/lib/graphql/activerecord.rb
@@ -31,6 +31,7 @@ module GraphQL
     # You can use this to access associated models inside custom field resolvers, without losing optimization
     # benefits.
     def self.load_association(starting_model, path, context)
+      path = Array.wrap(path)
       GraphQL::Models::DefinitionHelpers.load_and_traverse(starting_model, path, context)
     end
 

--- a/lib/graphql/models/definition_helpers/associations.rb
+++ b/lib/graphql/models/definition_helpers/associations.rb
@@ -87,7 +87,7 @@ module GraphQL
         fail ArgumentError.new("Association #{association} wasn't found on model #{model_type.name}") unless reflection
         fail ArgumentError.new("Cannot include #{reflection.macro} association #{association} on model #{model_type.name} with has_many_array") unless [:has_many].include?(reflection.macro)
 
-        type_lambda = options[:type] || -> { types["#{reflection.klass.name}Graph".constantize] }
+        type_lambda = options[:type] || -> { types[!"#{reflection.klass.name}Graph".constantize] }
         camel_name = options[:name] || association.to_s.camelize(:lower).to_sym
 
         DefinitionHelpers.register_field_metadata(graph_model_type, camel_name, {

--- a/lib/graphql/models/definition_helpers/associations.rb
+++ b/lib/graphql/models/definition_helpers/associations.rb
@@ -87,7 +87,7 @@ module GraphQL
         fail ArgumentError.new("Association #{association} wasn't found on model #{model_type.name}") unless reflection
         fail ArgumentError.new("Cannot include #{reflection.macro} association #{association} on model #{model_type.name} with has_many_array") unless [:has_many].include?(reflection.macro)
 
-        type_lambda = -> { types["#{reflection.klass.name}Graph".constantize] }
+        type_lambda = options[:type] || -> { types["#{reflection.klass.name}Graph".constantize] }
         camel_name = options[:name] || association.to_s.camelize(:lower).to_sym
 
         DefinitionHelpers.register_field_metadata(graph_model_type, camel_name, {

--- a/lib/graphql/models/definition_helpers/attributes.rb
+++ b/lib/graphql/models/definition_helpers/attributes.rb
@@ -2,6 +2,11 @@ module GraphQL
   module Models
     module DefinitionHelpers
       def self.type_to_graphql_type(type)
+        registered_type = ScalarTypes.registered_type(type)
+        if registered_type
+          return registered_type.is_a?(Proc) ? registered_type.call : registered_type
+        end
+
         case type
         when :boolean
           types.Boolean
@@ -9,11 +14,14 @@ module GraphQL
           types.Int
         when :float
           types.Float
-        when :daterange, :tsrange
-          types[!types.String]
+        when :daterange
+          inner_type = type_to_graphql_type(:date)
+          types[!inner_type]
+        when :tsrange
+          inner_type = type_to_graphql_type(:datetime)
+          types[!inner_type]
         else
-          resolved = ScalarTypes.registered_type(type) || types.String
-          resolved.is_a?(Proc) ? resolved.call : resolved
+          types.String
         end
       end
 

--- a/lib/graphql/models/monkey_patches/base_type.rb
+++ b/lib/graphql/models/monkey_patches/base_type.rb
@@ -3,6 +3,8 @@ module GraphQL::BaseType::HasPossibleTypes
   remove_const('DEFAULT_RESOLVE_TYPE')
 
   DEFAULT_RESOLVE_TYPE = -> (object) do
-    GraphQL::Relay::GlobalNodeIdentification.instance.type_from_object(object)
+    obj_type = GraphQL::Relay::GlobalNodeIdentification.instance.type_from_object(object)
+    return obj_type if possible_types.include?(obj_type)
+    nil
   end
 end


### PR DESCRIPTION
* Adds ability to specify graphql type for enums when using `graphql_enum` in models
* Allows overriding the default types used for attributes
* Fixes bug with `DEFAULT_RESOLVE_TYPE` monkey patch
* Date and time range attributes will now query for registered scalar types on `:date` and `:datetime`, and use those for the inner type of the arrays