### PR TITLE
Bug - connection crashing when polymorphic association = nil

### DIFF
--- a/lib/graphql/models/definition_helpers.rb
+++ b/lib/graphql/models/definition_helpers.rb
@@ -50,7 +50,10 @@ module GraphQL
           target_id = model.send(reflection.foreign_key)
 
           # If there isn't an associated model, mark the association loaded and return
-          mark_association_loaded(association, nil) and return true if target_id.nil?
+          if target_id.nil?
+            mark_association_loaded(association, nil)
+            return true
+          end
 
           # If the associated model isn't cached, return false
           target = context.cached_models.detect { |m| m.is_a?(association.klass) && m.id == target_id }


### PR DESCRIPTION
I'm querying the NotificationConnection and it's crashing when the `related_person == nil`

```
... on Notification {
            relatedPerson {
              ... on Person {
                firstName
                lastName
                photo {
                  id
                }
              }
            }
}
```


### Error
```
  "errors": [
    {
      "kind": "UNHANDLED_EXCEPTION",
      "message": "An error occurred while processing the query.",
      "exception": {
        "type": "TypeError",
        "message": "class or module required",
        "cause": null,
        "execution_context": {
          "graphql_type": "Notification",
          "field": "relatedPerson",
          "object_type": "PayrollDeductionChangeNotification",
          "object": "#<PayrollDeductionChangeNotification id: \"6553179e-cc76-45e4-909f-fefca8bac411\", type: \"PayrollDeductionChangeNotification\", status: 0, data: {\"pay_date\"=>\"2016-06-28\", \"number_employees\"=>3}, to_person_id: \"17848516-949c-482b-add9-318277ee4338\", company_id: \"8e802ca5-323f-479a-ba76-98ed27d628d8\", model_id: \"8e802ca5-323f-479a-ba76-98ed27d628d8\", model_type: \"Company\", created_at: \"2016-06-19 23:00:12\", updated_at: \"2016-06-29 19:16:48\", related_person_id: nil, related_person_type: nil, due_date: nil>",
          "args": {}
        },
        "backtrace": [
          "/Users/george/.rvm/gems/ruby-2.3.0@goco.io/gems/graphql-activerecord-0.6.4/lib/graphql/models/definition_helpers.rb:56:in `is_a?'",
          "/Users/george/.rvm/gems/ruby-2.3.0@goco.io/gems/graphql-activerecord-0.6.4/lib/graphql/models/definition_helpers.rb:56:in `block in attempt_cache_load'",
          "/Users/george/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/set.rb:306:in `each_key'",
          "/Users/george/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/set.rb:306:in `each'",
          "/Users/george/.rvm/gems/ruby-2.3.0@goco.io/ge
```

@theorygeek 