### PR TITLE
Allow Rails 5 dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /graphql-activerecord
     docker:
-      - image: ruby:2.3.1
+      - image: ruby:2.4.1
     steps:
       - checkout
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.3.0
-before_install: gem install bundler -v 1.11.2
+  - 2.4.1
+before_install: gem install bundler -v 1.14.6

--- a/graphql-activerecord.gemspec
+++ b/graphql-activerecord.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 4.2", '< 5'
-  spec.add_runtime_dependency "activerecord", ">= 4.2", '< 5'
+  spec.add_runtime_dependency "activesupport", ">= 4.2", '< 6'
+  spec.add_runtime_dependency "activerecord", ">= 4.2", '< 6'
   spec.add_runtime_dependency "graphql", ">= 1.5.10", '< 2'
   spec.add_runtime_dependency "graphql-batch", ">= 0.2.4"
 


### PR DESCRIPTION
This updates the CI to use Ruby 2.4.1 and allows Rails 5 apps to use this gem.