### PR TITLE
Find by ID fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [Unreleased]
+In mutators, the gem now supports updating nested models, where the `find_by` option specifies an ID field. This works similarly
+to input fields that accept ID values: it expects a global ID value to be provided, and uses your configured `model_from_id` proc
+to get the model's database ID.
+
 # 0.12.1
 Updates the gemspec to support Rails 5
 

--- a/README.md
+++ b/README.md
@@ -374,8 +374,8 @@ nested :emergency_contacts, find_by: :priority, null_behavior: :set_null do
 end
 ```
 
-This causes the gem to automatically include `priority` as an input field. Unfortunately, the only field you _can't_ use is the
-`id` field, because the gem isn't smart enough to map global ID's to model ID's. (This will be supported eventually, though.)
+This causes the gem to automatically include `priority` as an input field. You could also manually specify the
+`priority` field if you wanted to override its name or type.
 
 Also, an important note is that the gem assumes that you are passing up _all_ of the associated models, and not just some of
 them. It will destroy extra models, or create missing models.

--- a/lib/graphql/models/mutation_field_map.rb
+++ b/lib/graphql/models/mutation_field_map.rb
@@ -48,12 +48,15 @@ module GraphQL::Models
 
       detect_field_conflict(name)
 
-      fields.push({
+      # Delete the field, if it's already in the map
+      fields.reject! { |fd| fd[:attribute] == attribute }
+
+      fields << {
         name: name,
         attribute: attribute,
         type: type,
         required: required,
-      })
+      }
     end
 
     def proxy_to(association, &block)


### PR DESCRIPTION
Adds support for using the `nested` macro inside of mutators, where you pass an ID column to the `find_by` option.