### PR TITLE
Use `name.demodulize` for model_type

### DIFF
--- a/lib/graphql/models/definition_helpers/associations.rb
+++ b/lib/graphql/models/definition_helpers/associations.rb
@@ -41,7 +41,7 @@ module GraphQL
           graph_types = valid_types.map { |t| GraphQL::Models.get_graphql_type(t) }.compact
 
           GraphQL::UnionType.define do
-            name "#{model_type.name}#{reflection.foreign_type.classify}"
+            name "#{model_type.name.demodulize}#{reflection.foreign_type.classify}"
             description "Objects that can be used as #{reflection.foreign_type.titleize.downcase} on #{model_type.name.titleize.downcase}"
             possible_types graph_types
           end


### PR DESCRIPTION
It's a clone of #34, but because there are more commits on it, I created a new PR. We can keep using `name` but with `demodulize`, which will take out all modules names. And is the equivalent of `class_name`. e.g.: `'PublicActivity::Activity'.demodulize` will be `Activity`