### PR TITLE
Handle Unknown Scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# [Unreleased]
+Added unknown_scalar proc: https://github.com/goco-inc/graphql-activerecord/pull/45
+
 # 0.12.3
 - If possible, try to get the description for a field from the column's comment in the database. (#40)
 - Automatically generated union types (for polymorphic associations) used `demodulize` on the class name. If your model is `Name::Spaced`, this fixes a bug where it generates an invalid name. (#42)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ GraphQL::Models.unknown_scalar = -> (type, klass, attribute) do
   case type
   when :uuid
     UuidType
+  when :daterange
+    # If you need separate input/output types, use this syntax:
+    GraphQL::Models::DatabaseTypes::TypeStruct.new(DateRangeInputType, DateRangeOutputType)
   else
     GraphQL::STRING_TYPE
   end

--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ GraphQL::Models::DatabaseTypes.register(:decimal, "DecimalType")
 GraphQL::Models::DatabaseTypes.register(:date, DateType, DateInputType)
 ```
 
+You can also provide a proc, if you want a catch-all, or if it's different for different models:
+```ruby
+GraphQL::Models.unknown_scalar = -> (type, klass, attribute) do
+  case type
+  when :uuid
+    UuidType
+  else
+    GraphQL::STRING_TYPE
+  end
+end
+```
+
 #### Nullability of attributes
 The gem will mark a field as non-nullable if:
 - the database column is non-null

--- a/lib/graphql/activerecord.rb
+++ b/lib/graphql/activerecord.rb
@@ -38,7 +38,7 @@ require 'graphql/models/mutator'
 module GraphQL
   module Models
     class << self
-      attr_accessor :model_from_id, :authorize, :id_for_model, :model_to_graphql_type
+      attr_accessor :model_from_id, :authorize, :id_for_model, :model_to_graphql_type, :unknown_scalar
     end
 
     # Returns a promise that will traverse the associations and resolve to the model at the end of the path.

--- a/lib/graphql/models/reflection.rb
+++ b/lib/graphql/models/reflection.rb
@@ -62,6 +62,7 @@ module GraphQL::Models
           end
 
           if result.nil?
+            # rubocop:disable Metrics/LineLength
             raise "Don't know how to map database type #{active_record_type.type.inspect} to a GraphQL type. Forget to register it with GraphQL::Models::DatabaseTypes? (attribute #{attribute} on #{model_class.name})"
           end
 

--- a/lib/graphql/models/reflection.rb
+++ b/lib/graphql/models/reflection.rb
@@ -50,7 +50,7 @@ module GraphQL::Models
           result = DatabaseTypes.registered_type(active_record_type.type)
 
           if result.nil? && GraphQL::Models.unknown_scalar
-            type = GraphQL::Models.unknown_scalar.call(active_record_type.type)
+            type = GraphQL::Models.unknown_scalar.call(active_record_type.type, model_class, attribute)
 
             if type.is_a?(GraphQL::BaseType) && (type.unwrap.is_a?(GraphQL::ScalarType) || type.unwrap.is_a?(GraphQL::EnumType))
               result = DatabaseTypes::TypeStruct.new(type, type)


### PR DESCRIPTION
Oops, a few versions ago, I [inadvertently introduced an undocumented breaking change](https://github.com/goco-inc/graphql-activerecord/commit/97e03f549fdd41646f0c2f4149456974d7304067#diff-e1e821ee6d341ab0afa5dce7c8947437L20) with scalar behavior. Previously, this gem would assume:
- The `daterange` and `tsrange` types should be arrays of whatever type is used for `date` and `datetime` (respectively)
- Any unknown scalar should be a string

This change tries to make it possible to get the original behavior back by adding support for a catch-all proc. This needs to go in an intializer:
```ruby
GraphQL::Models.unknown_scalar = -> (type, klass, attribute) do
  # type will be something like :date, :datetime, :uuid, :tsrange
  # klass will be the class object for the model
  # attribute will be a symbol with the name of the attribute

  GraphQL::STRING_TYPE
end
```

For the `daterange` and `tsrange` types, you can't quite get back the original behavior of using an array. You _can_ map them to arrays, but on mutations, it'll try to assign the array to the attribute on your model :(

See the updated README for more details.