### PR TITLE
Update graphql-batch configuration documentation to remove deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ Finally, you need to set a few options on your schema:
 ```ruby
 GraphQL::Schema.define do
   # Set up the graphql-batch gem
-  lazy_resolve(Promise, :sync)
-  instrument(:query, GraphQL::Batch::Setup)
+  use GraphQL::Batch
 
   # Set up the graphql-activerecord gem
   instrument(:field, GraphQL::Models::Instrumentation.new)


### PR DESCRIPTION
The following is deprecated in the graphql-batch gem:
```ruby
  lazy_resolve(Promise, :sync)
  instrument(:query, GraphQL::Batch::Setup)
```
And returns the following warnings:
> Deprecated graphql-batch setup `instrument(:query, GraphQL::Batch::Setup)`, replace with `use GraphQL::Batch`

The new way of configuring graphql-batch is:
```ruby
  use GraphQL::Batch
```

These changes reflect the updated api in the documentation.