### PR TITLE
Fix typo in model_to_graph_type documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ GraphQL::Models.authorize = -> (context, action, model) {
 
 # The gem assumes that if your model is called `MyModel`, the corresponding type is `MyModelType`.
 # You can override that convention. Return `nil` if the model doesn't have a GraphQL type:
-GraphQL::Models.model_to_graphql_type = -> (model_class) { "#{model_class.name}Graph".safe_constantize }
+GraphQL::Models.model_to_graphql_type = -> (model_class) { "#{model_class.name}Type".safe_constantize }
 ```
 
 Finally, you need to set a few options on your schema:


### PR DESCRIPTION
Changed the configuration to reflect what you are describing above it.

> The gem assumes that if your model is called `MyModel`, the corresponding type is `MyModelType`.

Yet the default configuration was looking for `MyModelGraph` for models called `MyModel`.

Would be good to have the error message be a little bit more comprehensive and tell you what model it was expecting. (Guess that would be a good follow up pull request if I have some spare time)