### PR TITLE
add version notes for new tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 0.13.1
+Add fixes in relationship inferencing by using inversed_from instead of `inversed`
+
 # 0.13.0
 Changed the way that null values are handled inside of mutators. Take a look at [(#49)](https://github.com/goco-inc/graphql-activerecord/pull/49)
 for details. If you need to get back to the old behavior (ie, `unsetFields`), you can either:


### PR DESCRIPTION
Is it possible to get a new version for the current master branch of this gem? I proposed a new minor version update (v0.13.1). 
There is a fix [here](https://github.com/goco-inc/graphql-activerecord/blob/master/lib/graphql/models/mutation_helpers/apply_changes.rb#L96) that I've monkey patched locally but would love to remove the monkey patch in order to keep up with this gem.